### PR TITLE
fix network.lua

### DIFF
--- a/awesome/src/widgets/network.lua
+++ b/awesome/src/widgets/network.lua
@@ -297,7 +297,7 @@ return function()
                 }
                 function print_network_mode(){
                     check_network_directory
-                    print "${network_mode}"
+                    printf "${network_mode}"
                 }
                 print_network_mode
             ]=],


### PR DESCRIPTION
fixed print_network_mode returning a command not found when using bash shell.