### PR TITLE
Disable shadow for dock

### DIFF
--- a/picom.conf
+++ b/picom.conf
@@ -28,6 +28,7 @@ shadow-exclude = [
 	#"name = 'Dunst'",
 	#"name = 'dmenu'",
 	#"class_g = 'Rofi'",
+	"window_type = 'dock'",
 	"_GTK_FRAME_EXTENTS@:c",
 	"_NET_WM_STATE@:32a *= '_NET_WM_STATE_HIDDEN'"
 ];


### PR DESCRIPTION
this PR disables shadow for the dock box, which is a visual bug shown in the image.
![dock_shadow](https://user-images.githubusercontent.com/24689604/169642067-ebdaab66-3ecc-4527-af03-eebb23bab285.png)

**Note:** this also disables the shadow for the actual dock window.