### PR TITLE
Fix layout_list widget for multiple screens

### DIFF
--- a/awesome/crylia_bar/init.lua
+++ b/awesome/crylia_bar/init.lua
@@ -31,7 +31,7 @@ awful.screen.connect_for_each_screen(
   s.date = require("src.widgets.date")()
   s.clock = require("src.widgets.clock")()
   --s.bluetooth = require("src.widgets.bluetooth")()
-  s.layoutlist = require("src.widgets.layout_list")()
+  s.layoutlist = require("src.widgets.layout_list")(s)
   s.powerbutton = require("src.widgets.power")()
   s.kblayout = require("src.widgets.kblayout")(s)
   s.taglist = require("src.widgets.taglist")(s)

--- a/awesome/src/widgets/layout_list.lua
+++ b/awesome/src/widgets/layout_list.lua
@@ -11,11 +11,11 @@ local wibox = require("wibox")
 require("src.core.signals")
 
 -- Returns the layoutbox widget
-return function()
+return function(s)
   local layout = wibox.widget {
     {
       {
-        awful.widget.layoutbox(),
+        awful.widget.layoutbox(s),
         id = "icon_layout",
         widget = wibox.container.place
       },
@@ -29,7 +29,8 @@ return function()
     shape = function(cr, width, height)
       gears.shape.rounded_rect(cr, width, height, 5)
     end,
-    widget = wibox.container.background
+    widget = wibox.container.background,
+    screen = s
   }
 
   -- Signals
@@ -38,7 +39,7 @@ return function()
   layout:connect_signal(
     "button::press",
     function()
-      awful.layout.inc(-1)
+      awful.layout.inc(-1, s)
     end
   )
 


### PR DESCRIPTION
Fixes #36 
Please check if the config works at this state. Ironically, I don't have second monitor with me at the moment :smile: 
Expected behavior: Clicking on layout_list widget or changing the layout should work (change the icon) on multiple monitors