### PR TITLE
script removes the directory after creating the backup

### DIFF
--- a/autoinstall_arch.sh
+++ b/autoinstall_arch.sh
@@ -15,10 +15,9 @@ sudo pacman -S papirus-icon-theme pulseaudio-alsa upower bluez bluez-utils xorg-
 cd
 git clone --recurse-submodules https://github.com/Crylia/crylia-theme
 cd crylia-theme
-[ ! -d ~/.config/awesome ] && cp -r awesome ~/.config/. || cp -r ~/.config/awesome/ ~/.config/.awesome-backup && cp -r awesome ~/.config/.
-[ ! -f ~/.config/picom.conf ] && cp picom.conf ~/.config/. || cp ~/.config/picom.conf ~/.config/.picom.conf.backup && cp picom.conf ~/.config/.
-[ ! -d ~/.config/rofi ] && cp -r rofi ~/.config/. || cp -r ~/.config/rofi ~/.config/.rofi-backup && cp -r rofi ~/.config/.
-[ ! -d ~/.config/kitty ] && cp -r kitty ~/.config/. || cp -r ~/.config/kitty ~/.config/.kitty-backup && cp -r kitty ~/.config/.
-
+[ ! -d ~/.config/awesome ] 	&& cp -r awesome ~/.config/. || cp -r ~/.config/awesome/ ~/.config/.awesome-backup && rm -rf ~/.config/awesome/ && cp -r awesome ~/.config/.
+[ ! -f ~/.config/picom.conf ] 	&& cp picom.conf ~/.config/. || cp    ~/.config/picom.conf ~/.config/.picom.conf.backup && cp -f picom.conf ~/.config/.
+[ ! -d ~/.config/rofi ] 	&& cp -r rofi ~/.config/.    || cp -r ~/.config/rofi ~/.config/.rofi-backup && rm -rf ~/.config/rofi && cp -r rofi ~/.config/.
+[ ! -d ~/.config/kitty ] 	&& cp -r kitty ~/.config/.   || cp -r ~/.config/kitty ~/.config/.kitty-backup && rm -rf ~/.config/kitty && cp -r kitty ~/.config/.
 
 echo " ===== make sure to logout/reboot and select awesome desktop ====== "

--- a/autoinstall_pop_os.sh
+++ b/autoinstall_pop_os.sh
@@ -50,10 +50,10 @@ sudo ninja -C build install
 cd ~/$DIR
 git clone --recurse-submodules https://github.com/Crylia/crylia-theme
 cd crylia-theme
-[ ! -d ~/.config/awesome ] && cp -r awesome ~/.config/. || cp -r ~/.config/awesome/ ~/.config/.awesome-backup && cp -r awesome ~/.config/.
-[ ! -f ~/.config/picom.conf ] && cp picom.conf ~/.config/. || cp ~/.config/picom.conf ~/.config/.picom.conf.backup && cp picom.conf ~/.config/.
-[ ! -d ~/.config/rofi ] && cp -r rofi ~/.config/. || cp -r ~/.config/rofi ~/.config/.rofi-backup && cp -r rofi ~/.config/.
-[ ! -d ~/.config/kitty ] && cp -r kitty ~/.config/. || cp -r ~/.config/kitty ~/.config/.kitty-backup && cp -r kitty ~/.config/.
+[ ! -d ~/.config/awesome ] 	&& cp -r awesome ~/.config/. || cp -r ~/.config/awesome/ ~/.config/.awesome-backup && rm -rf ~/.config/awesome/ && cp -r awesome ~/.config/.
+[ ! -f ~/.config/picom.conf ] 	&& cp picom.conf ~/.config/. || cp    ~/.config/picom.conf ~/.config/.picom.conf.backup && cp -f picom.conf ~/.config/.
+[ ! -d ~/.config/rofi ] 	&& cp -r rofi ~/.config/.    || cp -r ~/.config/rofi ~/.config/.rofi-backup && rm -rf ~/.config/rofi && cp -r rofi ~/.config/.
+[ ! -d ~/.config/kitty ] 	&& cp -r kitty ~/.config/.   || cp -r ~/.config/kitty ~/.config/.kitty-backup && rm -rf ~/.config/kitty && cp -r kitty ~/.config/.
 
 
 echo " ===== make sure to logout/reboot and select awesome desktop ====== "


### PR DESCRIPTION
i was testing the script to see if it works for creating backups and yes it does, but `cp` just overlaps and overwrites  the directories with the files  of this repo.

for example this is my current `awesome` config: 
```
[~/git/crylia-theme]$ ls ~/.config/awesome
rc.lua idk/ test/
```
then i run the script and it copies the dir `awesome` to another called `.awesome-backup/` for then copying the `awesome` config folders and files of this repo to  `~/.config/awesome` but then this is my content
```
[~/git/crylia-theme]$ ls ~/.config/awesome
idk/  test/  crylia_bar/  mappings/  rc.lua  src/
```
i still have my old folders and `cp` overwrited the `rc.lua` file

now it creates the backup, then `rm -rf` the directory for then copying the configs of this repo 