### PR TITLE
fix: removed error popup as a result of nil value when changing sound slider

### DIFF
--- a/awesome/src/modules/volume_osd.lua
+++ b/awesome/src/modules/volume_osd.lua
@@ -99,11 +99,18 @@ return function(s)
     offset = dpi(5),
   }
 
+  local function is_not_a_number(value)
+    return value == nil or tonumber(value) == nil
+  end
+
   local function update_osd()
     awful.spawn.easy_async_with_shell(
       "./.config/awesome/src/scripts/vol.sh volume",
       function(stdout)
       local volume_level = stdout:gsub("\n", ""):gsub("%%", "")
+      if is_not_a_number(volume_level) then
+        return
+      end
       awesome.emit_signal("widget::volume")
       volume_osd_widget.container.osd_layout.icon_slider_layout.label_value_layout.value:set_text(volume_level .. "%")
 
@@ -152,8 +159,11 @@ return function(s)
         awful.spawn.easy_async_with_shell(
           "./.config/awesome/src/scripts/vol.sh volume",
           function(stdout2)
-          stdout2 = stdout2:gsub("%%", ""):gsub("\n", "")
-          volume_osd_widget.container.osd_layout.icon_slider_layout.slider_layout.volume_slider:set_value(tonumber(stdout2))
+          local volume_level = stdout2:gsub("%%", ""):gsub("\n", "")
+          if is_not_a_number(volume_level) then
+            return
+          end
+          volume_osd_widget.container.osd_layout.icon_slider_layout.slider_layout.volume_slider:set_value(tonumber(volume_level))
           update_osd()
         end
         )


### PR DESCRIPTION
# Changes

- Added null check for updating sound slider

# Why

When changing the sound with hardware like a Bose Pod dial, occasionally a large quantity of error popups appear describing that there was a nil value passed. This clogs up the screen providing a worse user experience. 
echo 'awesome.restart()' | awesome-client

# Solution

To resolve this, this PR adds error handling to both update sound number, and update sound slider. This prevents nil values from throwing an error when the code tries to convert the bash output to a number. 

# Testing 

1. echo 'awesome.restart()' | awesome-client
2. Use a sound dial and go above 100%, somewhere between 100-300% and quickly change the volume. There should no longer be any errors appearing