### PR TITLE
fix: fullscreen window cutoff issue by ensuring correct geometry is applied.

### DIFF
--- a/awesome/src/core/signals.lua
+++ b/awesome/src/core/signals.lua
@@ -79,6 +79,19 @@ client.connect_signal(
   end
 )
 
+-- Prevents fullscreen window cutoff.  
+client.connect_signal(
+  "property::fullscreen",
+  function(c)
+    if c.fullscreen then
+      c.floating = true
+      c:geometry(screen.primary.geometry)
+    else
+      c.floating = false
+    end
+  end
+)
+
 -- Workaround for focused border color, why in the love of god doesnt it work with
 -- beautiful.border_focus
 client.connect_signal(


### PR DESCRIPTION
# Changes

- Added listener that modifies screen size when entering and exiting full screen to prevent fullscreen cutoff

# Why

When entering full screen for an application like Firefox using MOD+f, the right side of the screen is cutoff. 

# Solution

To fix this, a condition is added that first converts the window to floating, and sets the screen size to match the window size. When exiting full screen, the floating condition is removed so that the layout of the current workspace remains the same.

# Testing

1. Load this change. 
2. Create a bunch of terminal windows and 1 Firefox window
3. Press SUPER+F and make Firefox full screen. Note that there is not right side cut off and the scroll bar is shown. 
4. Press SUPER+F again and ensure that the layout of all windows remains the same. 
